### PR TITLE
Fix SD prompt generation bug

### DIFF
--- a/sd/prompt.py
+++ b/sd/prompt.py
@@ -2,9 +2,10 @@ from utils.memory import MemoryManager
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_ollama import OllamaLLM
 import json
+import os
 
 
-def generate_sd_prompt(mem: MemoryManager, model_name="llama3") -> dict:
+def generate_sd_prompt(mem: MemoryManager, model_name="llama3", output_path: str | None = None) -> dict:
     """
     根據 MemoryManager 中的 summary 與 fact_memory
     使用 LLaMA3 產生一份適用於 Stable Diffusion 的 prompt JSON。
@@ -37,9 +38,10 @@ Extracted facts and inspiration:
     # Step 4: 嘗試轉成 JSON 格式
     try:
         result = json.loads(response)
-        with open(output_path, "w", encoding="utf-8") as f:
-            json.dump(result, f, indent=2, ensure_ascii=False)
-        print(f"✅ 已將生成的 prompt 存至 {os.path.abspath(output_path)}")
+        if output_path:
+            with open(output_path, "w", encoding="utf-8") as f:
+                json.dump(result, f, indent=2, ensure_ascii=False)
+            print(f"✅ 已將生成的 prompt 存至 {os.path.abspath(output_path)}")
         return result
     except json.JSONDecodeError:
         print("⚠️ 模型輸出不是合法 JSON: ")

--- a/utils/chat_logic.py
+++ b/utils/chat_logic.py
@@ -132,11 +132,14 @@ def process_turn(
     memory.update_summary(user_input, full_reply)
     memory.extract_facts(user_input, full_reply)
 
-    from sd.prompt import generate_sd_prompt  #
-    from utils.memory import MemoryManager  #
-    mem = MemoryManager()  #
-    result = generate_sd_prompt(mem)  #
-    print(result)  #
+    # Optional: generate a Stable Diffusion prompt from the current memory
+    from sd.prompt import generate_sd_prompt
+
+    try:
+        sd_prompt = generate_sd_prompt(memory)
+        print(sd_prompt)
+    except Exception as exc:
+        print(f"[process_turn] Failed to generate SD prompt: {exc}")
 
     # 5) Append to raw context
     new_context = (


### PR DESCRIPTION
## Summary
- add optional `output_path` param to Stable Diffusion prompt generator
- save prompt only if `output_path` provided
- use existing memory when generating SD prompt during chat

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68405b69f67c832ba9a57a64a2676e9c